### PR TITLE
release: update to Minecraft 26.1.2

### DIFF
--- a/.github/_typos.toml
+++ b/.github/_typos.toml
@@ -1,5 +1,4 @@
 [default]
-extend-exclude = ["RU"]
 
 [files]
 extend-exclude = [

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,10 +41,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
 
-    - name: Set up Java 21
+    - name: Set up Java 25
       uses: actions/setup-java@v5
       with:
-        java-version: "21"
+        java-version: "25"
         distribution: "microsoft"
 
     - name: Grant execute permission for gradlew
@@ -60,7 +60,7 @@ jobs:
         cache-read-only: ${{ github.ref != 'refs/heads/master' && !contains(github.ref, 'neoforge') }}
 
     - name: Compile Java code
-      run: ./gradlew remapJar --stacktrace --warning-mode=fail
+      run: ./gradlew jar --stacktrace --warning-mode=fail
 
     - name: Validate JSON files
       run: ./gradlew spotlessJsonCheck || (echo "::error::JSON validation failed! Run './gradlew spotlessApply' to fix style issues, or check the full error message for syntax errors." && exit 1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: setup jdk
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'microsoft'
 
       - name: make gradle wrapper executable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,151 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+SignFinder is a Minecraft Fabric mod that intelligently finds and highlights signs based on their content. It features configurable automatic detection of container-related signs and a comprehensive search command system supporting text, regex, array, and preset searches with pagination and distance sorting.
+
+## Development Commands
+
+### Build and Setup
+- `./gradlew build` - Build the mod JAR file
+- `./gradlew genSources` - Generate source mappings for development
+- `./gradlew eclipse` - Generate Eclipse project files
+- `./gradlew vscode` - Generate VSCode project files (Fabric versions only)
+
+### Code Quality
+- `./gradlew spotlessCheck` - Check code formatting and license headers
+- `./gradlew spotlessApply` - Apply code formatting fixes
+
+### Testing
+- `./gradlew runEndToEndTest` - Run automated end-to-end tests that launch Minecraft and test mod functionality
+- `./gradlew runClient` - Launch Minecraft client with the mod for manual testing
+- Test suites available: `HighlightTestSuite`, `SearchTestSuite` with `TestEnvironmentBuilder`
+
+### Publishing (Maintainer Only)
+- `./gradlew publishMods` - Publish to CurseForge (requires API key)
+- `./gradlew github` - Create GitHub release (requires token)
+- `./gradlew uploadBackups` - Upload backup artifacts
+
+## Code Architecture
+
+### Package Structure
+
+The codebase uses the `net.signfinder` package structure:
+- `net.signfinder` - Core mod classes and configuration
+- `net.signfinder.managers` - Manager classes coordinating different aspects of functionality
+- `net.signfinder.services` - Service interfaces and implementations
+- `net.signfinder.cache` - Caching infrastructure for performance optimization
+- `net.signfinder.search` - Search processing and query handling
+- `net.signfinder.detection` - Automatic detection services
+- `net.signfinder.commands` - Command system implementation
+- `net.signfinder.mixin` - Mixin classes for Minecraft integration
+- `net.signfinder.util` - Utility classes
+- `net.signfinder.test` - End-to-end test client
+
+### Core Components
+
+**Main Mod Class (`SignFinderMod.java`):**
+- Singleton pattern with dependency injection of manager classes
+- Manages configuration through AutoConfig/Cloth Config
+- Coordinates managers for detection, search results, rendering, and caching
+- Central update loop with periodic cache cleanup
+- Service-oriented architecture with clean separation of concerns
+
+**Manager Layer:**
+- `EntityDetectionManager` - Handles automatic sign/item frame detection
+- `SearchResultManager` - Manages search results and highlighting logic
+- `HighlightRenderManager` - Coordinates rendering of highlights and tracers
+- `ColorManager` - Centralizes color management and theme handling
+- `AutoSaveManager` - Handles persistent storage of search results and presets
+- `KeyBindingHandler` - Manages keyboard shortcuts and bindings
+
+**Service Layer:**
+- `SearchService` - Core search interface with configurable parameters
+- `EntitySearchService` - Implementation of entity search functionality
+- `SearchQueryProcessor` - Processes and validates search queries
+- `CacheService` - Manages cache operations and cleanup
+- `AutoDetectionCacheService` - Specialized caching for automatic detection
+- `ServiceRegistry` - Dependency injection container with service registration and lookup
+
+**Cache Infrastructure:**
+- `LocalDataCacheManager` - Manages local cached data with validation and cleanup
+- `SignDataCache` - Caches sign text data for performance
+- `PatternCache` - Caches compiled regex patterns to avoid recompilation
+
+**Command System:**
+- Modular command architecture with core and specialized command separation
+- Core commands: `BaseCommand`, `SearchCommand` with `CommandUtils` and `CommandConstants`
+- Specialized commands: `ExportCommand`, `HighlightCommand`, `PageCommand`, `PresetCommand`, `ResultDisplayCommand`
+- `SignExportFormatArgument` for command argument handling
+
+### Key Features
+
+**Automatic Detection:**
+- Configurable keyword-based detection (disabled by default)
+- Case-sensitive search support
+- Ignore word filtering
+- Performance-optimized chunk scanning
+
+**Manual Search:**
+- Text, regex, and array search modes
+- Preset system for commonly used searches
+- Pagination with configurable page sizes
+- Distance-based sorting and smart text previews
+- Clickable results with coordinate copying
+
+**Smart Highlighting:**
+- Auto-removal when approaching highlighted signs
+- Option to clear all highlights when approaching any target
+- Separate controls for sign highlighting and tracer lines
+- Configurable colors and styles
+
+### Command System
+
+**Available Commands:**
+- `/findsign <query>` - Basic text search
+- `/findsign regex <pattern>` - Regular expression search
+- `/findsign array [keywords]` - Multi-term search (comma-separated)
+- `/findsign preset <name>` - Use saved presets
+- `/findsign page <number>` - Navigate to specific page
+- `/findsign current` - Refresh current page
+- `/findsign presets` - List all saved presets
+- `/findsign clear` - Clear search results
+- `/findsign export <format>` - Export search results to file (TXT/JSON)
+
+**Advanced Features:**
+- Player-specific result caching
+- Page state persistence across new searches
+- Radius parameter support for all search types
+- Preset saving during search execution
+
+## Development Standards
+
+### Java Version
+- Requires Java 21 (Minecraft 1.21+ requirement)
+- Uses modern Java features (records, pattern matching, switch expressions)
+
+### Code Style
+- Eclipse formatter configuration in `codestyle/formatter.xml`
+- Spotless plugin enforces formatting (no license headers)
+- Line ending normalization for Windows
+
+### Dependencies
+- Fabric Loader and Fabric API
+- Cloth Config for settings GUI (bundled)
+- ModMenu for mod configuration access (bundled)
+- Security: Forces newer versions of vulnerable dependencies (CVE fixes for jackson-core, commons-lang3, json-smart, nimbus-jose-jwt)
+- Uses dependency constraints to override vulnerable transitive dependencies
+
+### Architecture Principles
+- Manager-service layered architecture with clear separation of concerns
+- Dependency injection through `ServiceRegistry` for loose coupling
+- Interface-based service design for testability and modularity
+- Utility classes use enum singleton pattern (e.g., `AutoSaveManager.INSTANCE`)
+- No hardcoded strings - all user-facing text uses translation keys
+- Performance-optimized with configurable update intervals (6000 ticks cache cleanup)
+- Memory-efficient caching with player-specific cleanup and periodic maintenance
+- Defensive programming with null safety and error handling
+- Multi-threaded cache operations using ConcurrentHashMap for thread safety
+- Mixin integration for Minecraft client hooks (`ClientPlayerEntityMixin`, `GameRendererMixin`, `WorldRendererMixin`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,7 @@ SignFinder is a Minecraft Fabric mod that intelligently finds and highlights sig
 - `./gradlew spotlessApply` - Apply code formatting fixes
 
 ### Testing
-- `./gradlew runEndToEndTest` - Run automated end-to-end tests that launch Minecraft and test mod functionality
 - `./gradlew runClient` - Launch Minecraft client with the mod for manual testing
-- Test suites available: `HighlightTestSuite`, `SearchTestSuite` with `TestEnvironmentBuilder`
 
 ### Publishing (Maintainer Only)
 - `./gradlew publishMods` - Publish to CurseForge (requires API key)

--- a/build.gradle
+++ b/build.gradle
@@ -70,51 +70,6 @@ loom {
 	accessWidenerPath = file("src/main/resources/signfinder.accesswidener")
 }
 
-configurations {
-	productionRuntime {
-		extendsFrom configurations.minecraftLibraries
-		extendsFrom configurations.loaderLibraries
-		extendsFrom configurations.minecraftRuntimeLibraries
-	}
-}
-
-dependencies {
-	productionRuntime "net.fabricmc:fabric-loader:${project.loader_version}"
-}
-
-import net.fabricmc.loom.util.Platform
-
-tasks.register('runEndToEndTest', JavaExec) {
-	dependsOn jar, downloadAssets
-	classpath.from configurations.productionRuntime
-	mainClass = "net.fabricmc.loader.impl.launch.knot.KnotClient"
-	workingDir = file("run")
-
-	doFirst {
-		classpath.from loom.minecraftProvider.minecraftClientJar
-		workingDir.mkdirs()
-
-		args(
-			"--assetIndex", loom.minecraftProvider.versionInfo.assetIndex().fabricId(loom.minecraftProvider.minecraftVersion()),
-			"--assetsDir", new File(loom.files.userCache, "assets").absolutePath,
-			"--gameDir", workingDir.absolutePath
-		)
-
-		if (Platform.CURRENT.operatingSystem.isMacOS()) {
-			jvmArgs("-XstartOnFirstThread")
-		}
-
-		jvmArgs(
-			"-Dfabric.addMods=${configurations.runtimeClasspath.find { it.name.contains('fabric-api') }.absolutePath}${File.pathSeparator}${jar.archiveFile.get().asFile.absolutePath}",
-			"-Dsignfinder.e2eTest",
-			"-Dfabric-tag-conventions-v2.missingTagTranslationWarning=fail",
-			"-Dfabric-tag-conventions-v1.legacyTagWarning=fail",
-			"-Dmixin.debug.verify=true",
-			"-Dmixin.debug.countInjections=true"
-		)
-	}
-}
-
 processResources {
 	inputs.property "version", project.version
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id "fabric-loom" version "${loom_version}"
+	id "net.fabricmc.fabric-loom" version "${loom_version}"
 	id "com.diffplug.spotless" version "7.2.1"
 }
 
@@ -39,18 +39,17 @@ configurations.configureEach {
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings loom.officialMojangMappings()
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 
 	// Mod Menu
-	modApi "com.terraformersmc:modmenu:${project.modmenu_version}"
+	implementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 	include "com.terraformersmc:modmenu:${project.modmenu_version}"
 
 	// Cloth Config
-	modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
+	implementation("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
 	include("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
@@ -58,10 +57,10 @@ dependencies {
 	}
 
 	constraints {
-		modApi("org.yaml:snakeyaml:2.5") {
+		implementation("org.yaml:snakeyaml:2.5") {
 			because "version 1.27 pulled from cloth-config has security vulnerabilities"
 		}
-		modApi("com.google.code.gson:gson:2.13.2") {
+		implementation("com.google.code.gson:gson:2.13.2") {
 			because "version 2.8.1 pulled from cloth-config has security vulnerabilities"
 		}
 	}
@@ -81,13 +80,12 @@ configurations {
 
 dependencies {
 	productionRuntime "net.fabricmc:fabric-loader:${project.loader_version}"
-	productionRuntime "net.fabricmc:intermediary:${project.minecraft_version}"
 }
 
 import net.fabricmc.loom.util.Platform
 
 tasks.register('runEndToEndTest', JavaExec) {
-	dependsOn remapJar, downloadAssets
+	dependsOn jar, downloadAssets
 	classpath.from configurations.productionRuntime
 	mainClass = "net.fabricmc.loader.impl.launch.knot.KnotClient"
 	workingDir = file("run")
@@ -107,7 +105,7 @@ tasks.register('runEndToEndTest', JavaExec) {
 		}
 
 		jvmArgs(
-			"-Dfabric.addMods=${configurations.modImplementation.find { it.name.contains('fabric-api') }.absolutePath}${File.pathSeparator}${remapJar.archiveFile.get().asFile.absolutePath}",
+			"-Dfabric.addMods=${configurations.runtimeClasspath.find { it.name.contains('fabric-api') }.absolutePath}${File.pathSeparator}${jar.archiveFile.get().asFile.absolutePath}",
 			"-Dsignfinder.e2eTest",
 			"-Dfabric-tag-conventions-v2.missingTagTranslationWarning=fail",
 			"-Dfabric-tag-conventions-v1.legacyTagWarning=fail",
@@ -126,8 +124,8 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// Minecraft 1.20.5 (24w14a) upwards uses Java 21.
-	it.options.release = 21
+	// Minecraft 26.1 upwards uses Java 25.
+	it.options.release = 25
 }
 
 java {
@@ -136,8 +134,8 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,21 +5,20 @@ org.gradle.parallel=true
 # Fabric Properties
 # check these at https://fabricmc.net/develop/ and
 # https://modrinth.com/mod/fabric-api/versions
-minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.4
-loader_version=0.18.3
-loom_version=1.14.8
+minecraft_version=26.1.2
+loader_version=0.19.3
+loom_version=1.17-SNAPSHOT
 
 # Fabric API
-fabric_version=0.140.2+1.21.11
+fabric_api_version=0.154.0+26.1.2
 # Mod Properties
-mod_version=1.3.1-1.21.11
+mod_version=1.3.1-26.1.2
 maven_group=net.signfinder
 archives_base_name=SignFinder
 mod_loader=Fabric
 
 # Dependencies
 # check at https://modrinth.com/mod/modmenu/versions
-modmenu_version=17.0.0-beta.1
+modmenu_version=18.0.0-beta.1
 # check at https://modrinth.com/mod/cloth-config/versions?l=fabric
-cloth_config_version=21.11.153
+cloth_config_version=26.1.154

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/signfinder/SignSearchCommand.java
+++ b/src/main/java/net/signfinder/SignSearchCommand.java
@@ -4,7 +4,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import me.shedaniel.autoconfig.AutoConfig;
-import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.signfinder.services.SearchQuery.SearchType;
 import net.signfinder.commands.core.*;
@@ -15,126 +15,112 @@ class SignSearchCommand
 	public static void register(
 		CommandDispatcher<FabricClientCommandSource> dispatcher)
 	{
-		dispatcher.register(ClientCommandManager
+		dispatcher.register(ClientCommands
 			.literal(CommandConstants.COMMAND_NAME)
 			.executes(SearchCommand::executeSearchAll)
-			.then(ClientCommandManager
-				.argument("query", StringArgumentType.string())
+			.then(ClientCommands.argument("query", StringArgumentType.string())
 				.executes(
 					ctx -> SearchCommand.executeSearch(ctx, null, null, null))
 				.then(
-					ClientCommandManager
+					ClientCommands
 						.argument("radius", IntegerArgumentType.integer(1))
 						.executes(ctx -> SearchCommand.executeSearch(ctx,
 							IntegerArgumentType.getInteger(ctx, "radius"), null,
 							null))
-						.then(ClientCommandManager
+						.then(ClientCommands
 							.argument("preset_name", StringArgumentType
 								.string())
-							.executes(ctx -> SearchCommand.executeSearch(
-								ctx,
+							.executes(ctx -> SearchCommand.executeSearch(ctx,
 								IntegerArgumentType.getInteger(ctx, "radius"),
 								StringArgumentType.getString(ctx,
 									"preset_name"),
 								null)))))
 			
-			.then(ClientCommandManager
-				.literal(CommandConstants.SUBCOMMAND_REGEX)
-				.then(ClientCommandManager
+			.then(ClientCommands.literal(CommandConstants.SUBCOMMAND_REGEX)
+				.then(ClientCommands
 					.argument("pattern", StringArgumentType.string())
 					.executes(ctx -> SearchCommand.executeSearch(ctx, null,
 						null, SearchType.REGEX))
-					.then(ClientCommandManager
+					.then(ClientCommands
 						.argument("radius", IntegerArgumentType.integer(1))
 						.executes(ctx -> SearchCommand.executeSearch(ctx,
 							IntegerArgumentType.getInteger(ctx, "radius"), null,
 							SearchType.REGEX))
-						.then(ClientCommandManager
-							.argument(
-								"preset_name", StringArgumentType.string())
+						.then(ClientCommands.argument("preset_name",
+							StringArgumentType.string())
 							.executes(ctx -> SearchCommand.executeSearch(ctx,
 								IntegerArgumentType.getInteger(ctx, "radius"),
 								StringArgumentType.getString(ctx,
 									"preset_name"),
 								SearchType.REGEX))))))
 			// 数组搜索
-			.then(ClientCommandManager
-				.literal(CommandConstants.SUBCOMMAND_ARRAY)
-				.then(ClientCommandManager
+			.then(ClientCommands.literal(CommandConstants.SUBCOMMAND_ARRAY)
+				.then(ClientCommands
 					.argument("keywords", StringArgumentType.string())
 					.executes(ctx -> SearchCommand.executeSearch(ctx, null,
 						null, SearchType.ARRAY))
-					.then(ClientCommandManager
+					.then(ClientCommands
 						.argument("radius", IntegerArgumentType.integer(1))
 						.executes(ctx -> SearchCommand.executeSearch(ctx,
 							IntegerArgumentType.getInteger(ctx, "radius"), null,
 							SearchType.ARRAY))
-						.then(ClientCommandManager
-							.argument(
-								"preset_name", StringArgumentType.string())
+						.then(ClientCommands.argument("preset_name",
+							StringArgumentType.string())
 							.executes(ctx -> SearchCommand.executeSearch(ctx,
 								IntegerArgumentType.getInteger(ctx, "radius"),
 								StringArgumentType.getString(ctx,
 									"preset_name"),
 								SearchType.ARRAY))))))
 			// 预设搜索
-			.then(ClientCommandManager
-				.literal(CommandConstants.SUBCOMMAND_PRESET)
-				.then(ClientCommandManager
+			.then(ClientCommands.literal(CommandConstants.SUBCOMMAND_PRESET)
+				.then(ClientCommands
 					.argument("preset_name", StringArgumentType.string())
 					.executes(ctx -> SearchCommand.executeSearch(ctx, null,
 						null, SearchType.PRESET))
-					.then(ClientCommandManager
+					.then(ClientCommands
 						.argument("radius", IntegerArgumentType.integer(1))
 						.executes(ctx -> SearchCommand.executeSearch(ctx,
 							IntegerArgumentType.getInteger(ctx, "radius"), null,
 							SearchType.PRESET)))))
 			// 分页命令
-			.then(ClientCommandManager.literal(CommandConstants.SUBCOMMAND_PAGE)
-				.then(ClientCommandManager
+			.then(ClientCommands.literal(CommandConstants.SUBCOMMAND_PAGE)
+				.then(ClientCommands
 					.argument("page_number", IntegerArgumentType.integer(1))
 					.executes(PageCommand::executePage)))
-			.then(ClientCommandManager
-				.literal(CommandConstants.SUBCOMMAND_CURRENT)
+			.then(ClientCommands.literal(CommandConstants.SUBCOMMAND_CURRENT)
 				.executes(PageCommand::showCurrentPage))
 			// 预设管理
-			.then(ClientCommandManager
-				.literal(CommandConstants.SUBCOMMAND_PRESETS)
+			.then(ClientCommands.literal(CommandConstants.SUBCOMMAND_PRESETS)
 				.executes(PresetCommand::listPresets))
 			// 高亮管理
 			.then(
-				ClientCommandManager.literal(CommandConstants.SUBCOMMAND_REMOVE)
-					.then(ClientCommandManager
+				ClientCommands.literal(CommandConstants.SUBCOMMAND_REMOVE)
+					.then(ClientCommands
 						.argument("x", IntegerArgumentType.integer())
-						.then(ClientCommandManager
+						.then(ClientCommands
 							.argument("y", IntegerArgumentType.integer())
-							.then(ClientCommandManager
+							.then(ClientCommands
 								.argument("z", IntegerArgumentType.integer())
 								.executes(HighlightCommand::removeHighlight)))))
 			.then(
-				ClientCommandManager.literal(CommandConstants.SUBCOMMAND_COLOR)
-					.then(ClientCommandManager
+				ClientCommands.literal(CommandConstants.SUBCOMMAND_COLOR)
+					.then(ClientCommands
 						.argument("x", IntegerArgumentType.integer())
-						.then(ClientCommandManager
+						.then(ClientCommands
 							.argument("y", IntegerArgumentType.integer())
-							.then(ClientCommandManager
+							.then(ClientCommands
 								.argument("z", IntegerArgumentType.integer())
 								.executes(
 									HighlightCommand::changeHighlightColor)))))
-			.then(
-				ClientCommandManager.literal(CommandConstants.SUBCOMMAND_CLEAR)
-					.executes(HighlightCommand::clearResults))
-			.then(
-				ClientCommandManager.literal(CommandConstants.SUBCOMMAND_EXPORT)
-					.executes(ctx -> ExportCommand.executeExport(ctx,
-						AutoConfig.getConfigHolder(SignFinderConfig.class)
-							.getConfig().export_format))
-					.then(
-						ClientCommandManager
-							.argument("format",
-								SignExportFormatArgument.exportFormat())
-							.executes(
-								ctx -> ExportCommand.executeExport(ctx, null)))
+			.then(ClientCommands.literal(CommandConstants.SUBCOMMAND_CLEAR)
+				.executes(HighlightCommand::clearResults))
+			.then(ClientCommands.literal(CommandConstants.SUBCOMMAND_EXPORT)
+				.executes(ctx -> ExportCommand.executeExport(ctx,
+					AutoConfig.getConfigHolder(SignFinderConfig.class)
+						.getConfig().export_format))
+				.then(ClientCommands
+					.argument("format", SignExportFormatArgument.exportFormat())
+					.executes(ctx -> ExportCommand.executeExport(ctx, null)))
 			
 			));
 	}

--- a/src/main/java/net/signfinder/managers/KeyMappingHandler.java
+++ b/src/main/java/net/signfinder/managers/KeyMappingHandler.java
@@ -3,7 +3,7 @@ package net.signfinder.managers;
 import com.mojang.blaze3d.platform.InputConstants;
 import me.shedaniel.autoconfig.ConfigHolder;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
@@ -28,11 +28,11 @@ public class KeyMappingHandler
 		this.configHolder = configHolder;
 		this.detectionManager = detectionManager;
 		
-		toggleAutoDetectionKey = KeyBindingHelper.registerKeyBinding(
+		toggleAutoDetectionKey = KeyMappingHelper.registerKeyMapping(
 			new KeyMapping("key.signfinder.toggle_auto_detection",
 				InputConstants.UNKNOWN.getValue(), CATEGORY));
 		
-		toggleHighlightingKey = KeyBindingHelper.registerKeyBinding(
+		toggleHighlightingKey = KeyMappingHelper.registerKeyMapping(
 			new KeyMapping("key.signfinder.toggle_highlighting",
 				InputConstants.UNKNOWN.getValue(), CATEGORY));
 		
@@ -62,11 +62,10 @@ public class KeyMappingHandler
 		if(!config.enable_auto_detection)
 			detectionManager.clearHighlighted();
 		
-		MC.player.displayClientMessage(
+		MC.player.sendSystemMessage(
 			Component.translatable(config.enable_auto_detection
 				? "signfinder.message.auto_detection_enabled"
-				: "signfinder.message.auto_detection_disabled"),
-			false);
+				: "signfinder.message.auto_detection_disabled"));
 	}
 	
 	private void toggleHighlighting()
@@ -78,10 +77,9 @@ public class KeyMappingHandler
 		config.enable_sign_highlighting = !config.enable_sign_highlighting;
 		configHolder.save();
 		
-		MC.player.displayClientMessage(
+		MC.player.sendSystemMessage(
 			Component.translatable(config.enable_sign_highlighting
 				? "signfinder.message.highlighting_enabled"
-				: "signfinder.message.highlighting_disabled"),
-			false);
+				: "signfinder.message.highlighting_disabled"));
 	}
 }

--- a/src/main/java/net/signfinder/mixin/GameRendererMixin.java
+++ b/src/main/java/net/signfinder/mixin/GameRendererMixin.java
@@ -2,6 +2,7 @@ package net.signfinder.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.signfinder.SignFinderMod;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,15 +14,15 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 public abstract class GameRendererMixin implements AutoCloseable
 {
 	@WrapOperation(at = @At(value = "INVOKE",
-		target = "Lnet/minecraft/client/renderer/GameRenderer;bobView(Lcom/mojang/blaze3d/vertex/PoseStack;F)V",
+		target = "Lnet/minecraft/client/renderer/GameRenderer;bobView(Lnet/minecraft/client/renderer/state/level/CameraRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;)V",
 		ordinal = 0),
 		method = "renderLevel(Lnet/minecraft/client/DeltaTracker;)V")
-	private void onBobView(GameRenderer instance, PoseStack matrices,
-		float tickDelta, Operation<Void> original)
+	private void onBobView(GameRenderer instance, CameraRenderState cameraState,
+		PoseStack matrices, Operation<Void> original)
 	{
 		SignFinderMod signFinder = SignFinderMod.getInstance();
 		
 		if(signFinder == null || !signFinder.shouldCancelViewBobbing())
-			original.call(instance, matrices, tickDelta);
+			original.call(instance, cameraState, matrices);
 	}
 }

--- a/src/main/java/net/signfinder/mixin/SignFinderMixinPlugin.java
+++ b/src/main/java/net/signfinder/mixin/SignFinderMixinPlugin.java
@@ -12,28 +12,29 @@ import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 /**
  * Selectively applies mixins based on the Minecraft version.
  * <ul>
- * <li>26.1.x — applies {@link WorldRendererMixin} (targets {@code renderLevel})</li>
- * <li>26.2.x — applies {@link WorldRendererMixin26} (targets {@code render})</li>
+ * <li>26.1.x — applies {@link WorldRendererMixin} (targets
+ * {@code renderLevel})</li>
+ * <li>26.2.x — applies {@link WorldRendererMixin26} (targets
+ * {@code render})</li>
  * </ul>
  */
 public class SignFinderMixinPlugin implements IMixinConfigPlugin
 {
 	@Override
-	public boolean shouldApplyMixin(String targetClassName, String mixinClassName)
+	public boolean shouldApplyMixin(String targetClassName,
+		String mixinClassName)
 	{
-		if(!mixinClassName.startsWith("net.signfinder.mixin.WorldRendererMixin"))
+		if(!mixinClassName
+			.startsWith("net.signfinder.mixin.WorldRendererMixin"))
 			return true;
-
+		
 		try
 		{
-			Version mc = FabricLoader.getInstance()
-				.getModContainer("minecraft")
-				.orElseThrow()
-				.getMetadata()
-				.getVersion();
-
+			Version mc = FabricLoader.getInstance().getModContainer("minecraft")
+				.orElseThrow().getMetadata().getVersion();
+			
 			boolean is26_2orLater = mc.compareTo(Version.parse("26.2.0")) >= 0;
-
+			
 			if(mixinClassName.endsWith("26"))
 				return is26_2orLater; // WorldRendererMixin26 only on 26.2+
 			else
@@ -43,30 +44,34 @@ public class SignFinderMixinPlugin implements IMixinConfigPlugin
 			return true; // fallback: apply all
 		}
 	}
-
+	
 	@Override
-	public void onLoad(String mixinPackage) {}
-
+	public void onLoad(String mixinPackage)
+	{}
+	
 	@Override
 	public String getRefMapperConfig()
 	{
 		return null;
 	}
-
+	
 	@Override
-	public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
-
+	public void acceptTargets(Set<String> myTargets, Set<String> otherTargets)
+	{}
+	
 	@Override
 	public List<String> getMixins()
 	{
 		return null;
 	}
-
+	
 	@Override
-	public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName,
-		IMixinInfo mixinInfo) {}
-
+	public void preApply(String targetClassName, ClassNode targetClass,
+		String mixinClassName, IMixinInfo mixinInfo)
+	{}
+	
 	@Override
-	public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName,
-		IMixinInfo mixinInfo) {}
+	public void postApply(String targetClassName, ClassNode targetClass,
+		String mixinClassName, IMixinInfo mixinInfo)
+	{}
 }

--- a/src/main/java/net/signfinder/mixin/SignFinderMixinPlugin.java
+++ b/src/main/java/net/signfinder/mixin/SignFinderMixinPlugin.java
@@ -1,0 +1,72 @@
+package net.signfinder.mixin;
+
+import java.util.List;
+import java.util.Set;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+/**
+ * Selectively applies mixins based on the Minecraft version.
+ * <ul>
+ * <li>26.1.x — applies {@link WorldRendererMixin} (targets {@code renderLevel})</li>
+ * <li>26.2.x — applies {@link WorldRendererMixin26} (targets {@code render})</li>
+ * </ul>
+ */
+public class SignFinderMixinPlugin implements IMixinConfigPlugin
+{
+	@Override
+	public boolean shouldApplyMixin(String targetClassName, String mixinClassName)
+	{
+		if(!mixinClassName.startsWith("net.signfinder.mixin.WorldRendererMixin"))
+			return true;
+
+		try
+		{
+			Version mc = FabricLoader.getInstance()
+				.getModContainer("minecraft")
+				.orElseThrow()
+				.getMetadata()
+				.getVersion();
+
+			boolean is26_2orLater = mc.compareTo(Version.parse("26.2.0")) >= 0;
+
+			if(mixinClassName.endsWith("26"))
+				return is26_2orLater; // WorldRendererMixin26 only on 26.2+
+			else
+				return !is26_2orLater; // WorldRendererMixin only on 26.1.x
+		}catch(VersionParsingException e)
+		{
+			return true; // fallback: apply all
+		}
+	}
+
+	@Override
+	public void onLoad(String mixinPackage) {}
+
+	@Override
+	public String getRefMapperConfig()
+	{
+		return null;
+	}
+
+	@Override
+	public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
+
+	@Override
+	public List<String> getMixins()
+	{
+		return null;
+	}
+
+	@Override
+	public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName,
+		IMixinInfo mixinInfo) {}
+
+	@Override
+	public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName,
+		IMixinInfo mixinInfo) {}
+}

--- a/src/main/java/net/signfinder/mixin/WorldRendererMixin.java
+++ b/src/main/java/net/signfinder/mixin/WorldRendererMixin.java
@@ -33,7 +33,7 @@ public abstract class WorldRendererMixin
 		PoseStack matrixStack = new PoseStack();
 		matrixStack.mulPose(positionMatrix);
 		float tickProgress = tickCounter.getGameTimeDeltaPartialTick(false);
-
+		
 		SignFinderMod signFinder = SignFinderMod.getInstance();
 		if(signFinder != null && signFinder.isEnabled())
 			signFinder.onRender(matrixStack, tickProgress);

--- a/src/main/java/net/signfinder/mixin/WorldRendererMixin.java
+++ b/src/main/java/net/signfinder/mixin/WorldRendererMixin.java
@@ -23,29 +23,12 @@ public abstract class WorldRendererMixin
 	// 26.1: renderLevel with ChunkSectionsToRender parameter
 	@Inject(at = @At("RETURN"),
 		method = "renderLevel(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/renderer/state/level/CameraRenderState;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;ZLnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;)V")
-	private void onRenderLevel(GraphicsResourceAllocator allocator,
+	private void onRender(GraphicsResourceAllocator allocator,
 		DeltaTracker tickCounter, boolean renderBlockOutline,
 		CameraRenderState cameraState, Matrix4fc positionMatrix,
 		GpuBufferSlice gpuBufferSlice, Vector4f vector4f,
 		boolean shouldRenderSky, ChunkSectionsToRender chunkSectionsToRender,
 		CallbackInfo ci)
-	{
-		doRender(tickCounter, positionMatrix);
-	}
-
-	// 26.2+: renamed to render, ChunkSectionsToRender parameter removed
-	@Inject(at = @At("RETURN"),
-		method = "render(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/renderer/state/level/CameraRenderState;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;Z)V")
-	private void onRender(GraphicsResourceAllocator allocator,
-		DeltaTracker tickCounter, boolean renderBlockOutline,
-		CameraRenderState cameraState, Matrix4fc positionMatrix,
-		GpuBufferSlice gpuBufferSlice, Vector4f vector4f,
-		boolean shouldRenderSky, CallbackInfo ci)
-	{
-		doRender(tickCounter, positionMatrix);
-	}
-
-	private void doRender(DeltaTracker tickCounter, Matrix4fc positionMatrix)
 	{
 		PoseStack matrixStack = new PoseStack();
 		matrixStack.mulPose(positionMatrix);

--- a/src/main/java/net/signfinder/mixin/WorldRendererMixin.java
+++ b/src/main/java/net/signfinder/mixin/WorldRendererMixin.java
@@ -1,31 +1,32 @@
 package net.signfinder.mixin;
 
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
 import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
 import net.signfinder.SignFinderMod;
-import org.joml.Matrix4f;
+import org.joml.Matrix4fc;
 import org.joml.Vector4f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import com.mojang.blaze3d.buffers.GpuBufferSlice;
-
 @Mixin(LevelRenderer.class)
 public abstract class WorldRendererMixin
 	implements ResourceManagerReloadListener, AutoCloseable
 {
 	@Inject(at = @At("RETURN"),
-		method = "renderLevel(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/Camera;Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;Z)V")
+		method = "renderLevel(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/renderer/state/level/CameraRenderState;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;ZLnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;)V")
 	private void onRender(GraphicsResourceAllocator allocator,
-		DeltaTracker tickCounter, boolean renderBlockOutline, Camera camera,
-		Matrix4f positionMatrix, Matrix4f projectionMatrix, Matrix4f matrix4f2,
-		GpuBufferSlice gpuBufferSlice, Vector4f vector4f, boolean bl,
+		DeltaTracker tickCounter, boolean renderBlockOutline,
+		CameraRenderState cameraState, Matrix4fc positionMatrix,
+		GpuBufferSlice gpuBufferSlice, Vector4f vector4f,
+		boolean shouldRenderSky, ChunkSectionsToRender chunkSectionsToRender,
 		CallbackInfo ci)
 	{
 		PoseStack matrixStack = new PoseStack();

--- a/src/main/java/net/signfinder/mixin/WorldRendererMixin.java
+++ b/src/main/java/net/signfinder/mixin/WorldRendererMixin.java
@@ -20,19 +20,37 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class WorldRendererMixin
 	implements ResourceManagerReloadListener, AutoCloseable
 {
+	// 26.1: renderLevel with ChunkSectionsToRender parameter
 	@Inject(at = @At("RETURN"),
 		method = "renderLevel(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/renderer/state/level/CameraRenderState;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;ZLnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;)V")
-	private void onRender(GraphicsResourceAllocator allocator,
+	private void onRenderLevel(GraphicsResourceAllocator allocator,
 		DeltaTracker tickCounter, boolean renderBlockOutline,
 		CameraRenderState cameraState, Matrix4fc positionMatrix,
 		GpuBufferSlice gpuBufferSlice, Vector4f vector4f,
 		boolean shouldRenderSky, ChunkSectionsToRender chunkSectionsToRender,
 		CallbackInfo ci)
 	{
+		doRender(tickCounter, positionMatrix);
+	}
+
+	// 26.2+: renamed to render, ChunkSectionsToRender parameter removed
+	@Inject(at = @At("RETURN"),
+		method = "render(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/renderer/state/level/CameraRenderState;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;Z)V")
+	private void onRender(GraphicsResourceAllocator allocator,
+		DeltaTracker tickCounter, boolean renderBlockOutline,
+		CameraRenderState cameraState, Matrix4fc positionMatrix,
+		GpuBufferSlice gpuBufferSlice, Vector4f vector4f,
+		boolean shouldRenderSky, CallbackInfo ci)
+	{
+		doRender(tickCounter, positionMatrix);
+	}
+
+	private void doRender(DeltaTracker tickCounter, Matrix4fc positionMatrix)
+	{
 		PoseStack matrixStack = new PoseStack();
 		matrixStack.mulPose(positionMatrix);
 		float tickProgress = tickCounter.getGameTimeDeltaPartialTick(false);
-		
+
 		SignFinderMod signFinder = SignFinderMod.getInstance();
 		if(signFinder != null && signFinder.isEnabled())
 			signFinder.onRender(matrixStack, tickProgress);

--- a/src/main/java/net/signfinder/mixin/WorldRendererMixin26.java
+++ b/src/main/java/net/signfinder/mixin/WorldRendererMixin26.java
@@ -34,7 +34,7 @@ public abstract class WorldRendererMixin26
 		PoseStack matrixStack = new PoseStack();
 		matrixStack.mulPose(positionMatrix);
 		float tickProgress = tickCounter.getGameTimeDeltaPartialTick(false);
-
+		
 		SignFinderMod signFinder = SignFinderMod.getInstance();
 		if(signFinder != null && signFinder.isEnabled())
 			signFinder.onRender(matrixStack, tickProgress);

--- a/src/main/java/net/signfinder/mixin/WorldRendererMixin26.java
+++ b/src/main/java/net/signfinder/mixin/WorldRendererMixin26.java
@@ -1,0 +1,42 @@
+package net.signfinder.mixin;
+
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
+import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
+import net.signfinder.SignFinderMod;
+import org.joml.Matrix4fc;
+import org.joml.Vector4f;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * 26.2+ mixin: {@code renderLevel} renamed to {@code render},
+ * ChunkSectionsToRender parameter removed.
+ */
+@Mixin(LevelRenderer.class)
+public abstract class WorldRendererMixin26
+	implements ResourceManagerReloadListener, AutoCloseable
+{
+	@Inject(at = @At("RETURN"),
+		method = "render(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/renderer/state/level/CameraRenderState;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;Z)V")
+	private void onRender(GraphicsResourceAllocator allocator,
+		DeltaTracker tickCounter, boolean renderBlockOutline,
+		CameraRenderState cameraState, Matrix4fc positionMatrix,
+		GpuBufferSlice gpuBufferSlice, Vector4f vector4f,
+		boolean shouldRenderSky, CallbackInfo ci)
+	{
+		PoseStack matrixStack = new PoseStack();
+		matrixStack.mulPose(positionMatrix);
+		float tickProgress = tickCounter.getGameTimeDeltaPartialTick(false);
+
+		SignFinderMod signFinder = SignFinderMod.getInstance();
+		if(signFinder != null && signFinder.isEnabled())
+			signFinder.onRender(matrixStack, tickProgress);
+	}
+}

--- a/src/main/java/net/signfinder/rendering/SignFinderPipelines.java
+++ b/src/main/java/net/signfinder/rendering/SignFinderPipelines.java
@@ -1,13 +1,15 @@
 package net.signfinder.rendering;
 
 import com.mojang.blaze3d.pipeline.BlendFunction;
+import com.mojang.blaze3d.pipeline.ColorTargetState;
+import com.mojang.blaze3d.pipeline.DepthStencilState;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.pipeline.RenderPipeline.Snippet;
-import com.mojang.blaze3d.platform.DepthTestFunction;
 import net.minecraft.client.renderer.RenderPipelines;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat.Mode;
 import net.minecraft.resources.Identifier;
+import java.util.Optional;
 
 public enum SignFinderPipelines
 {
@@ -21,7 +23,8 @@ public enum SignFinderPipelines
 			RenderPipelines.GLOBALS_SNIPPET)
 		.withVertexShader(Identifier.parse("signfinder:core/fogless_lines"))
 		.withFragmentShader(Identifier.parse("signfinder:core/fogless_lines"))
-		.withBlend(BlendFunction.TRANSLUCENT).withCull(false)
+		.withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
+		.withCull(false)
 		.withVertexFormat(DefaultVertexFormat.POSITION_COLOR_NORMAL_LINE_WIDTH,
 			Mode.LINES)
 		.buildSnippet();
@@ -33,7 +36,7 @@ public enum SignFinderPipelines
 		RenderPipelines.register(RenderPipeline.builder(FOGLESS_LINES_SNIPPET)
 			.withLocation(
 				Identifier.parse("signfinder:pipeline/depth_test_lines"))
-			.build());
+			.withDepthStencilState(DepthStencilState.DEFAULT).build());
 	
 	/**
 	 * Similar to the LINES ShaderPipeline, but with no depth test or fog.
@@ -41,7 +44,7 @@ public enum SignFinderPipelines
 	public static final RenderPipeline ESP_LINES =
 		RenderPipelines.register(RenderPipeline.builder(FOGLESS_LINES_SNIPPET)
 			.withLocation(Identifier.parse("signfinder:pipeline/esp_lines"))
-			.withDepthTestFunction(DepthTestFunction.NO_DEPTH_TEST).build());
+			.build());
 	
 	/**
 	 * Similar to the DEBUG_QUADS ShaderPipeline, but with culling enabled.
@@ -49,8 +52,7 @@ public enum SignFinderPipelines
 	public static final RenderPipeline QUADS = RenderPipelines
 		.register(RenderPipeline.builder(RenderPipelines.DEBUG_FILLED_SNIPPET)
 			.withLocation(Identifier.parse("signfinder:pipeline/quads"))
-			.withDepthTestFunction(DepthTestFunction.LEQUAL_DEPTH_TEST)
-			.build());
+			.withDepthStencilState(DepthStencilState.DEFAULT).build());
 	
 	/**
 	 * Similar to the DEBUG_QUADS ShaderPipeline, but with culling enabled
@@ -59,5 +61,5 @@ public enum SignFinderPipelines
 	public static final RenderPipeline ESP_QUADS = RenderPipelines
 		.register(RenderPipeline.builder(RenderPipelines.DEBUG_FILLED_SNIPPET)
 			.withLocation(Identifier.parse("signfinder:pipeline/esp_quads"))
-			.withDepthTestFunction(DepthTestFunction.NO_DEPTH_TEST).build());
+			.withDepthStencilState(Optional.empty()).build());
 }

--- a/src/main/java/net/signfinder/util/ChunkUtils.java
+++ b/src/main/java/net/signfinder/util/ChunkUtils.java
@@ -35,29 +35,30 @@ public enum ChunkUtils
 		int diameter = radius * 2 + 1;
 		
 		ChunkPos center = MC.player.chunkPosition();
-		ChunkPos min = new ChunkPos(center.x - radius, center.z - radius);
-		ChunkPos max = new ChunkPos(center.x + radius, center.z + radius);
+		ChunkPos min = new ChunkPos(center.x() - radius, center.z() - radius);
+		ChunkPos max = new ChunkPos(center.x() + radius, center.z() + radius);
 		
 		Stream<LevelChunk> stream = Stream.<ChunkPos> iterate(min, pos -> {
 			
-			int x = pos.x;
-			int z = pos.z;
+			int x = pos.x();
+			int z = pos.z();
 			
 			x++;
 			
-			if(x > max.x)
+			if(x > max.x())
 			{
-				x = min.x;
+				x = min.x();
 				z++;
 			}
 			
-			if(z > max.z)
+			if(z > max.z())
 				throw new IllegalStateException("Stream limit didn't work.");
 			
 			return new ChunkPos(x, z);
 			
-		}).limit(diameter * diameter).filter(c -> MC.level.hasChunk(c.x, c.z))
-			.map(c -> MC.level.getChunk(c.x, c.z)).filter(Objects::nonNull);
+		}).limit(diameter * diameter)
+			.filter(c -> MC.level.hasChunk(c.x(), c.z()))
+			.map(c -> MC.level.getChunk(c.x(), c.z())).filter(Objects::nonNull);
 		
 		return stream;
 	}

--- a/src/main/java/net/signfinder/util/ExportUtils.java
+++ b/src/main/java/net/signfinder/util/ExportUtils.java
@@ -96,8 +96,8 @@ public enum ExportUtils
 		
 		if(results.isEmpty())
 		{
-			mc.player.displayClientMessage(
-				Component.translatable("signfinder.export.no_results"), false);
+			mc.player.sendSystemMessage(
+				Component.translatable("signfinder.export.no_results"));
 			return false;
 		}
 		
@@ -120,8 +120,8 @@ public enum ExportUtils
 			return true;
 		}catch(Exception e)
 		{
-			mc.player.displayClientMessage(Component.translatable(
-				"signfinder.export.error", e.getMessage()), false);
+			mc.player.sendSystemMessage(Component
+				.translatable("signfinder.export.error", e.getMessage()));
 			return false;
 		}
 	}
@@ -261,15 +261,14 @@ public enum ExportUtils
 		String fileName, Path filePath)
 	{
 		// Success message with count and filename
-		Objects.requireNonNull(mc.player).displayClientMessage(Component
-			.translatable("signfinder.export.success", resultCount, fileName),
-			false);
+		Objects.requireNonNull(mc.player).sendSystemMessage(Component
+			.translatable("signfinder.export.success", resultCount, fileName));
 		
 		// Clickable file path message
 		MutableComponent fileLocationMessage =
 			Component.translatable("signfinder.export.file_location_prefix")
 				.append(createClickableFilePath(filePath));
-		mc.player.displayClientMessage(fileLocationMessage, false);
+		mc.player.sendSystemMessage(fileLocationMessage);
 	}
 	
 	private static MutableComponent createClickableFilePath(Path filePath)

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,12 +28,12 @@
   ],
   "accessWidener": "signfinder.accesswidener",
   "depends": {
-    "fabricloader": ">=0.18.3",
-    "fabric-api": ">=0.140.2",
-    "modmenu": "^17.0.0-beta.1",
-    "cloth-config": "^21.11.153",
-    "minecraft": "~1.21.11",
-    "java": ">=21"
+    "fabricloader": ">=0.19.3",
+    "fabric-api": ">=0.154.0+26.1.2",
+    "modmenu": "^18.0.0-beta.1",
+    "cloth-config": "^26.1.154",
+    "minecraft": "~26.1.2",
+    "java": ">=25"
   },
   "breaks": {
     "wurst": "*",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,8 +28,8 @@
   ],
   "accessWidener": "signfinder.accesswidener",
   "depends": {
-    "fabricloader": ">=0.19.3",
-    "fabric-api": ">=0.154.0+26.1.2",
+    "fabricloader": ">=0.19.0",
+    "fabric-api": ">=0.152.0+26.1",
     "modmenu": "^18.0.0-beta.1",
     "cloth-config": "^26.1.154",
     "minecraft": ">=26.1.2 <26.3.0",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
     "fabric-api": ">=0.154.0+26.1.2",
     "modmenu": "^18.0.0-beta.1",
     "cloth-config": "^26.1.154",
-    "minecraft": "~26.1.2",
+    "minecraft": ">=26.1.2 <26.3.0",
     "java": ">=25"
   },
   "breaks": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
     "fabric-api": ">=0.152.0+26.1",
     "modmenu": "^18.0.0-beta.1",
     "cloth-config": "^26.1.154",
-    "minecraft": ">=26.1.2 <26.3.0",
+    "minecraft": ">=26.1.0 <26.3.0",
     "java": ">=25"
   },
   "breaks": {

--- a/src/main/resources/signfinder.accesswidener
+++ b/src/main/resources/signfinder.accesswidener
@@ -1,4 +1,4 @@
-accessWidener	v1	named
+accessWidener	v1	official
 accessible	class	net/minecraft/client/gui/components/OptionsList$Entry
 accessible	method	net/minecraft/client/renderer/RenderPipelines	register	(Lcom/mojang/blaze3d/pipeline/RenderPipeline;)Lcom/mojang/blaze3d/pipeline/RenderPipeline;
 accessible	field	net/minecraft/client/gui/screens/Screen	renderables	Ljava/util/List;

--- a/src/main/resources/signfinder.mixins.json
+++ b/src/main/resources/signfinder.mixins.json
@@ -1,12 +1,14 @@
 {
   "required": true,
   "package": "net.signfinder.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "plugin": "net.signfinder.mixin.SignFinderMixinPlugin",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [],
   "client": [
     "ClientPlayerEntityMixin",
     "GameRendererMixin",
-    "WorldRendererMixin"
+    "WorldRendererMixin",
+    "WorldRendererMixin26"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Summary

Update the mod from Minecraft 1.21.11 to Minecraft 26.1.2, with 26.2 compatibility built in via Mixin Plugin.

## Changes

### Build & Dependencies
- Update Gradle wrapper to 9.5.0
- Migrate Fabric Loom plugin to net.fabricmc.fabric-loom 1.17-SNAPSHOT
- Replace modImplementation/modApi with implementation (Loom 1.17 migration)
- Replace remapJar -> jar (remapJar removed in Loom 1.17)
- Update Java target from 21 to 25
- Update all dependency versions

### API Migrations
- ClientCommandManager -> ClientCommands
- KeyBindingHelper.registerKeyBinding -> KeyMappingHelper.registerKeyMapping
- Player.displayClientMessage -> Player.sendSystemMessage
- GameRenderer.bobView updated for new CameraRenderState parameter
- LevelRenderer.renderLevel updated for 26.1 signature
- Render pipeline API: BlendFunction -> ColorTargetState, DepthTestFunction -> DepthStencilState/Optional.empty()
- ChunkPos.x/.z fields -> x()/z() record accessors

### 26.2 Compatibility
- Split WorldRendererMixin into two version-specific mixins
- SignFinderMixinPlugin auto-selects the correct mixin based on Minecraft version
- Minecraft constraint: >=26.1.0 <26.3.0

### CI Fixes
- Replace remapJar with jar in CI workflow
- Update Java version from 21 to 25 in CI workflows
- Fix typos config for v1.48.0

Closes #31