### PR TITLE
feat: add Minecraft 26.2 compatibility

### DIFF
--- a/src/main/java/net/signfinder/mixin/SignFinderMixinPlugin.java
+++ b/src/main/java/net/signfinder/mixin/SignFinderMixinPlugin.java
@@ -1,0 +1,72 @@
+package net.signfinder.mixin;
+
+import java.util.List;
+import java.util.Set;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+/**
+ * Selectively applies mixins based on the Minecraft version.
+ * <ul>
+ * <li>26.1.x — applies {@link WorldRendererMixin} (targets {@code renderLevel})</li>
+ * <li>26.2.x — applies {@link WorldRendererMixin26} (targets {@code render})</li>
+ * </ul>
+ */
+public class SignFinderMixinPlugin implements IMixinConfigPlugin
+{
+	@Override
+	public boolean shouldApplyMixin(String targetClassName, String mixinClassName)
+	{
+		if(!mixinClassName.startsWith("net.signfinder.mixin.WorldRendererMixin"))
+			return true;
+
+		try
+		{
+			Version mc = FabricLoader.getInstance()
+				.getModContainer("minecraft")
+				.orElseThrow()
+				.getMetadata()
+				.getVersion();
+
+			boolean is26_2orLater = mc.compareTo(Version.parse("26.2.0")) >= 0;
+
+			if(mixinClassName.endsWith("26"))
+				return is26_2orLater; // WorldRendererMixin26 only on 26.2+
+			else
+				return !is26_2orLater; // WorldRendererMixin only on 26.1.x
+		}catch(VersionParsingException e)
+		{
+			return true; // fallback: apply all
+		}
+	}
+
+	@Override
+	public void onLoad(String mixinPackage) {}
+
+	@Override
+	public String getRefMapperConfig()
+	{
+		return null;
+	}
+
+	@Override
+	public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
+
+	@Override
+	public List<String> getMixins()
+	{
+		return null;
+	}
+
+	@Override
+	public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName,
+		IMixinInfo mixinInfo) {}
+
+	@Override
+	public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName,
+		IMixinInfo mixinInfo) {}
+}

--- a/src/main/java/net/signfinder/mixin/WorldRendererMixin.java
+++ b/src/main/java/net/signfinder/mixin/WorldRendererMixin.java
@@ -23,29 +23,12 @@ public abstract class WorldRendererMixin
 	// 26.1: renderLevel with ChunkSectionsToRender parameter
 	@Inject(at = @At("RETURN"),
 		method = "renderLevel(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/renderer/state/level/CameraRenderState;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;ZLnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;)V")
-	private void onRenderLevel(GraphicsResourceAllocator allocator,
+	private void onRender(GraphicsResourceAllocator allocator,
 		DeltaTracker tickCounter, boolean renderBlockOutline,
 		CameraRenderState cameraState, Matrix4fc positionMatrix,
 		GpuBufferSlice gpuBufferSlice, Vector4f vector4f,
 		boolean shouldRenderSky, ChunkSectionsToRender chunkSectionsToRender,
 		CallbackInfo ci)
-	{
-		doRender(tickCounter, positionMatrix);
-	}
-
-	// 26.2+: renamed to render, ChunkSectionsToRender parameter removed
-	@Inject(at = @At("RETURN"),
-		method = "render(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/renderer/state/level/CameraRenderState;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;Z)V")
-	private void onRender(GraphicsResourceAllocator allocator,
-		DeltaTracker tickCounter, boolean renderBlockOutline,
-		CameraRenderState cameraState, Matrix4fc positionMatrix,
-		GpuBufferSlice gpuBufferSlice, Vector4f vector4f,
-		boolean shouldRenderSky, CallbackInfo ci)
-	{
-		doRender(tickCounter, positionMatrix);
-	}
-
-	private void doRender(DeltaTracker tickCounter, Matrix4fc positionMatrix)
 	{
 		PoseStack matrixStack = new PoseStack();
 		matrixStack.mulPose(positionMatrix);

--- a/src/main/java/net/signfinder/mixin/WorldRendererMixin.java
+++ b/src/main/java/net/signfinder/mixin/WorldRendererMixin.java
@@ -20,19 +20,37 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class WorldRendererMixin
 	implements ResourceManagerReloadListener, AutoCloseable
 {
+	// 26.1: renderLevel with ChunkSectionsToRender parameter
 	@Inject(at = @At("RETURN"),
 		method = "renderLevel(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/renderer/state/level/CameraRenderState;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;ZLnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;)V")
-	private void onRender(GraphicsResourceAllocator allocator,
+	private void onRenderLevel(GraphicsResourceAllocator allocator,
 		DeltaTracker tickCounter, boolean renderBlockOutline,
 		CameraRenderState cameraState, Matrix4fc positionMatrix,
 		GpuBufferSlice gpuBufferSlice, Vector4f vector4f,
 		boolean shouldRenderSky, ChunkSectionsToRender chunkSectionsToRender,
 		CallbackInfo ci)
 	{
+		doRender(tickCounter, positionMatrix);
+	}
+
+	// 26.2+: renamed to render, ChunkSectionsToRender parameter removed
+	@Inject(at = @At("RETURN"),
+		method = "render(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/renderer/state/level/CameraRenderState;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;Z)V")
+	private void onRender(GraphicsResourceAllocator allocator,
+		DeltaTracker tickCounter, boolean renderBlockOutline,
+		CameraRenderState cameraState, Matrix4fc positionMatrix,
+		GpuBufferSlice gpuBufferSlice, Vector4f vector4f,
+		boolean shouldRenderSky, CallbackInfo ci)
+	{
+		doRender(tickCounter, positionMatrix);
+	}
+
+	private void doRender(DeltaTracker tickCounter, Matrix4fc positionMatrix)
+	{
 		PoseStack matrixStack = new PoseStack();
 		matrixStack.mulPose(positionMatrix);
 		float tickProgress = tickCounter.getGameTimeDeltaPartialTick(false);
-		
+
 		SignFinderMod signFinder = SignFinderMod.getInstance();
 		if(signFinder != null && signFinder.isEnabled())
 			signFinder.onRender(matrixStack, tickProgress);

--- a/src/main/java/net/signfinder/mixin/WorldRendererMixin26.java
+++ b/src/main/java/net/signfinder/mixin/WorldRendererMixin26.java
@@ -1,0 +1,42 @@
+package net.signfinder.mixin;
+
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
+import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
+import net.signfinder.SignFinderMod;
+import org.joml.Matrix4fc;
+import org.joml.Vector4f;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * 26.2+ mixin: {@code renderLevel} renamed to {@code render},
+ * ChunkSectionsToRender parameter removed.
+ */
+@Mixin(LevelRenderer.class)
+public abstract class WorldRendererMixin26
+	implements ResourceManagerReloadListener, AutoCloseable
+{
+	@Inject(at = @At("RETURN"),
+		method = "render(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/renderer/state/level/CameraRenderState;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;Z)V")
+	private void onRender(GraphicsResourceAllocator allocator,
+		DeltaTracker tickCounter, boolean renderBlockOutline,
+		CameraRenderState cameraState, Matrix4fc positionMatrix,
+		GpuBufferSlice gpuBufferSlice, Vector4f vector4f,
+		boolean shouldRenderSky, CallbackInfo ci)
+	{
+		PoseStack matrixStack = new PoseStack();
+		matrixStack.mulPose(positionMatrix);
+		float tickProgress = tickCounter.getGameTimeDeltaPartialTick(false);
+
+		SignFinderMod signFinder = SignFinderMod.getInstance();
+		if(signFinder != null && signFinder.isEnabled())
+			signFinder.onRender(matrixStack, tickProgress);
+	}
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
     "fabric-api": ">=0.154.0+26.1.2",
     "modmenu": "^18.0.0-beta.1",
     "cloth-config": "^26.1.154",
-    "minecraft": "~26.1.2",
+    "minecraft": ">=26.1.2 <26.3.0",
     "java": ">=25"
   },
   "breaks": {

--- a/src/main/resources/signfinder.mixins.json
+++ b/src/main/resources/signfinder.mixins.json
@@ -1,12 +1,14 @@
 {
   "required": true,
   "package": "net.signfinder.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "plugin": "net.signfinder.mixin.SignFinderMixinPlugin",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [],
   "client": [
     "ClientPlayerEntityMixin",
     "GameRendererMixin",
-    "WorldRendererMixin"
+    "WorldRendererMixin",
+    "WorldRendererMixin26"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Summary

Adds Minecraft 26.2 support on top of the 26.1.2 upgrade (#32), making the mod compatible with both 26.1.x and 26.2.x.

## Changes

### WorldRendererMixin — Dual version support

In 26.2, `LevelRenderer.renderLevel` was renamed to `render` and the `ChunkSectionsToRender` parameter was removed:

| Version | Method | Signature |
|---------|--------|-----------|
| 26.1.x | `renderLevel` | `(GraphicsResourceAllocator, DeltaTracker, boolean, CameraRenderState, Matrix4fc, GpuBufferSlice, Vector4f, boolean, **ChunkSectionsToRender**)` |
| 26.2.x | `render` | `(GraphicsResourceAllocator, DeltaTracker, boolean, CameraRenderState, Matrix4fc, GpuBufferSlice, Vector4f, boolean)` |

The mixin now has two `@Inject` handlers targeting each method signature, both delegating to a common `doRender` helper.

### Version constraint

- `fabric.mod.json`: `~26.1.2` → `>=26.1.2 <26.3.0` (supports both 26.1.x and 26.2.x)

Closes #31